### PR TITLE
Fix queue of incoming messages to ELLX which cause busy to lie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Log levels of serial communication logging
+
+### Fixed
+- Queue problem with ELLX devices which cause busy to toggle early
+
 ## [2022.4.0]
 
 ### Fixed


### PR DESCRIPTION
Adds a boolean flag that allows the queue to flush without setting busy
to false.

Resets the flag when the queue is empty, allowing both new items to
be requested and busy to go False correctly.

Also, messed with some log levels
